### PR TITLE
Making Reducer a three param Generic.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,11 +27,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
     }
     buildFeatures {
         compose = true

--- a/app/src/main/java/fraktal/io/android/demo/MainActivity.kt
+++ b/app/src/main/java/fraktal/io/android/demo/MainActivity.kt
@@ -4,19 +4,13 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
-import com.fraktalio.fmodel.application.EventSourcingAggregate
-import com.fraktalio.fmodel.application.handle
 import fraktal.io.android.demo.timer.domain.timerDecider
 import fraktal.io.android.demo.theme.DemoAndroidTheme
+import fraktal.io.android.demo.timer.domain.TimerCommand
+import fraktal.io.android.demo.timer.domain.TimerEvent
+import fraktal.io.android.demo.timer.ui.TimerStateMapper
 import fraktal.io.android.demo.timer.ui.TimerView
+import fraktal.io.android.demo.timer.ui.TimerViewState
 import fraktal.io.android.demo.timer.ui.TimerViewStateMapper
 import fraktal.io.ext.Reducer
 import kotlinx.coroutines.CoroutineScope
@@ -36,9 +30,14 @@ class MainActivity : ComponentActivity() {
 
 
 object DI {
-    val timerReducer = Reducer(
-        decider = timerDecider(),
+    // Feel free to use Mapper functions on the Decider here.
+    // Notice how you need to provide two Map functions, in both direction (from TimerViewState to TimerState, and from TimerState to TimerViewState)
+    private val timerDecider =
+        timerDecider().dimapOnState(::TimerStateMapper, ::TimerViewStateMapper)
+
+    //At this point the Reducer is aware only of TimerViewState type
+    val timerReducer: Reducer<TimerCommand, TimerViewState, TimerEvent> = Reducer(
+        decider = timerDecider,
         scope = CoroutineScope(Dispatchers.IO),
-        uiMapper = ::TimerViewStateMapper
     )
 }

--- a/app/src/main/java/fraktal/io/android/demo/timer/ui/TimerMapper.kt
+++ b/app/src/main/java/fraktal/io/android/demo/timer/ui/TimerMapper.kt
@@ -4,6 +4,11 @@ import fraktal.io.android.demo.timer.domain.TimerCommand
 import fraktal.io.android.demo.timer.domain.TimerState
 import java.util.concurrent.TimeUnit
 
+/**
+ * Map domain TimerState to UI TimerViewState.
+ *
+ * Check the MainActivity for usage of this mapping function
+ */
 fun TimerViewStateMapper(state: TimerState?): TimerViewState {
     return when {
         state == null -> TimerViewState(
@@ -13,9 +18,13 @@ fun TimerViewStateMapper(state: TimerState?): TimerViewState {
 
         (state.all == 0L) && state.isStopped.not() -> TimerViewState(
             formatTime(state.all),
+
             listOf(
                 TimerViewState.ButtonState("Start", TimerCommand.Start)
-            )
+            ),
+            state.all,
+            state.period,
+            state.isStopped,
         )
 
         state.isStopped -> TimerViewState(
@@ -23,12 +32,32 @@ fun TimerViewStateMapper(state: TimerState?): TimerViewState {
             listOf(
                 TimerViewState.ButtonState("Resume", TimerCommand.Resume),
                 TimerViewState.ButtonState("Reset", TimerCommand.Reset),
-            )
+            ),
+            state.all,
+            state.period,
+            state.isStopped,
         )
 
-        else -> TimerViewState(formatTime(state.all), listOf(TimerViewState.ButtonState("Stop", TimerCommand.Stop)))
+        else -> TimerViewState(
+            formatTime(state.all),
+            listOf(TimerViewState.ButtonState("Stop", TimerCommand.Stop)),
+            state.all,
+            state.period,
+            state.isStopped,
+        )
     }
 }
+
+/**
+ * Map TimerViewState to domain TimerState.
+ *
+ * Check the MainActivity for usage of this mapping function
+ *
+ * In this example, this direction of mapping from UI state into Domain state is not needed because the Decider is creating/emiting new states/events without reading the current state from DB or UI.
+ * In more evolved demos this might be needed.
+ */
+fun TimerStateMapper(state: TimerViewState): TimerState =
+    TimerState(state.all ?: 0, state.period ?: 0, state.isStopped)
 
 
 private fun formatTime(milliseconds: Long?): String {

--- a/app/src/main/java/fraktal/io/android/demo/timer/ui/TimerView.kt
+++ b/app/src/main/java/fraktal/io/android/demo/timer/ui/TimerView.kt
@@ -29,17 +29,16 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import fraktal.io.android.demo.timer.domain.TimerCommand
 import fraktal.io.android.demo.timer.domain.TimerEvent
-import fraktal.io.android.demo.timer.domain.TimerState
 import fraktal.io.ext.Reducer
 import kotlinx.coroutines.launch
 
 
 @Composable
 fun TimerView(
-    reducer: Reducer<TimerCommand, TimerState, TimerViewState, TimerEvent>
+    reducer: Reducer<TimerCommand, TimerViewState, TimerEvent>
 ) {
     val uiScope = rememberCoroutineScope()
-    val state by reducer.uiStates.collectAsState()
+    val state by reducer.states.collectAsState()
     val event by reducer.events.collectAsState(initial = null)
 
     Render(timerState = state, timerAnimation = event is TimerEvent.OnNewTimerCreated) {
@@ -50,7 +49,11 @@ fun TimerView(
 }
 
 @Composable
-private fun Render(timerState: TimerViewState, timerAnimation: Boolean, onClick: (TimerCommand) -> Unit) {
+private fun Render(
+    timerState: TimerViewState,
+    timerAnimation: Boolean,
+    onClick: (TimerCommand) -> Unit
+) {
     Box(modifier = Modifier.fillMaxSize()) {
         RenderText(timerState.timerText, timerAnimation)
 
@@ -113,7 +116,7 @@ private fun PreviewButtons() {
         Box(modifier = Modifier.padding(it))
         Render(
             timerState = TimerViewState(
-                "02:54",
+                "",
                 listOf(
                     TimerViewState.ButtonState("reset", TimerCommand.Reset),
                     TimerViewState.ButtonState("resume", TimerCommand.Resume),

--- a/app/src/main/java/fraktal/io/android/demo/timer/ui/TimerViewState.kt
+++ b/app/src/main/java/fraktal/io/android/demo/timer/ui/TimerViewState.kt
@@ -6,7 +6,10 @@ import fraktal.io.android.demo.timer.domain.TimerCommand
 @Stable
 data class TimerViewState(
     val timerText: String,
-    val buttons: List<ButtonState>
+    val buttons: List<ButtonState>,
+    val all: Long? = null,
+    val period: Long? = null,
+    val isStopped: Boolean = false,
 ) {
 
     @Stable


### PR DESCRIPTION
I have added some minor changes to the source code.

I hope that Reducer can be a 3-param generic, and not a 4.

Once you have your core domain logic implemented as a `Decider<C, S, E>`, reducer can use it. But, before it does that, it can map that decider into another `Decider<C, S_new, E>` that might not expose internal state / `S`.  Decider is a functor over S parameter and provides `dimapOnState` function that can be used for that. 

`dimapOnState` requires two functions: mapping in both directions